### PR TITLE
docs(external-suppliers): add executive summary

### DIFF
--- a/docs/externalsuppliers_executive_summary.md
+++ b/docs/externalsuppliers_executive_summary.md
@@ -1,0 +1,37 @@
+# How can you integrate your solution into the OS2Skole system?
+
+*   **Open Source & Standards:** The architecture uses pre-existing open-source components with standard ways to connect.
+*   **Multi-Vendor Setup:** OS2Skole is designed in a multi-vendor environment where different vendors compete to provide the specific open-source components they specialize in.
+*   **Integration Points:** Integration involves connecting with our central login service, a straightforward process, and interfacing with pre-existing open-source components via their established communication standards.
+*   **Minimal Custom-Built Code:** We aim to keep custom "OS2Skole code" to a minimum; understanding the standard components is all that is required to integrate into our system.
+
+# What will the process of integrating with OS2Skole look like?
+
+*   **Agile Development:** Integration occurs within an agile framework using short work cycles, where we gather extensive feedback from test users to adjust with each iteration.
+*   **Vendor Responsibility:** We expect you to develop, maintain, and configure the integrations required for your application to function within the OS2Skole ecosystem.
+*   **Vendor Collaboration:** We invite you to participate in the testing process to ensure end users are satisfied with how your system integrates with OS2Skole.
+*   **Automated Quality Assurance:** We use a automated release and update process with an automated test suite. We encourage you to contribute your own test modules to this suite. This way, we can ensure that future system upgrades do not degrade the functionality of your integration.
+
+# Should we get developing right away?
+
+We are not yet tied to specific providers and applications. We will know and share the technical integration requirements once the vendors for the individual components have been selected.
+
+---
+
+# Hvordan kan I integrere jeres løsning i OS2Skole-systemet?
+
+* **Open source og standarder:** Arkitekturen bruger eksisterende open source-komponenter med standardiserede forbindelsesmetoder.
+* **Multi-vendor-opsætning:** OS2Skole er designet til et multi-vendor-miljø, hvor forskellige leverandører konkurrerer om at levere de specifikke open source-komponenter, de har specialiseret sig i.
+* **Integrationspunkter:** Integrationen indebærer tilslutning til vores centrale login-tjeneste, en enkel proces, og integration med eksisterende open source-komponenter via deres etablerede kommunikationsstandarder.
+* **Minimal specialudviklet kode:** Vi tilstræber at holde den specialudviklede »OS2Skole-kode« på et minimum; det eneste, der kræves for at integrere i vores system, er forståelse for standardkomponenterne.
+
+# Hvordan vil integrationsprocessen med OS2Skole se ud?
+
+* **Agil udvikling:** Integrationen foregår inden for en agil ramme med korte arbejdscyklusser, hvor vi indsamler omfattende feedback fra testbrugere for at justere med hver iteration.
+* **Leverandøransvar:** Vi forventer, at I udvikler, vedligeholder og konfigurerer de integrationer, der er nødvendige for, at jeres applikation kan fungere inden for OS2Skole-økosystemet.
+* **Leverandørsamarbejde:** Vi inviterer jer til at deltage i testprocessen for at sikre, at slutbrugerne er tilfredse med, hvordan jeres system integreres med OS2Skole.
+* **Automatiseret kvalitetssikring:** Vi bruger en automatiseret release- og opdateringsproces med en automatiseret testsuite. Vi anbefaler jer at bidrage med jeres egne testmoduler til denne suite. På denne måde kan vi sikre, at fremtidige systemopgraderinger ikke påvirker funktionaliteten af jeres integration negativt.
+
+# Skal vi gå i gang med udviklingen med det samme?
+
+Vi er endnu ikke bundet til bestemte udbydere og applikationer. Vi vil kende og dele de tekniske integrationskrav, når leverandørerne til de enkelte komponenter er blevet udvalgt.


### PR DESCRIPTION
I got the feedback that the architecture communication canvas is too verbose for the presentation, so I have created this shorter document.

resolves: #49 