### PR TITLE
Embed the existing system landscape diagram into a markdown file

### DIFF
--- a/top_level_design/system_landscape.md
+++ b/top_level_design/system_landscape.md
@@ -5,7 +5,8 @@ This diagram provides a high-level overview of the system components.
 ![C4 System Landscape Diagram](./diagram_data/system_landscape_diagram.svg)
 
 ## Context
-**Date:** Dec 17, 2025, **Author:** [@0xf1e](https://github.com/0xf1e), **Discussion:** https://github.com/OS2sandbox/os2skole-PoC/pull/46
+**Date:** Dec 17, 2025, **Author:** [@0xf1e](https://github.com/0xf1e)  
+**Discussion Participants:** Input from [@janhalen](https://github.com/janhalen), https://github.com/OS2sandbox/os2skole-PoC/pull/46
 
 **Originally intended Audience and Purpose:**  
 

--- a/top_level_design/system_landscape.md
+++ b/top_level_design/system_landscape.md
@@ -1,0 +1,16 @@
+# C4 System Landscape Diagram
+
+This diagram provides a high-level overview of the system components.
+
+![C4 System Landscape Diagram](./top_level_design/diagram_data/system_landscape_diagram.svg)
+
+## Context
+**Date:** Dec 17, 2025, **Author:** @0xf1e, **Discussion:** https://github.com/OS2sandbox/os2skole-PoC/pull/46
+
+**Originally intended Audience and Purpose:**
+(a) For our own team: Outline the project's technical requirements.
+(b) For external partners and stakeholders: Outline the overall scope and integration points.
+
+## Implied Decisions
+
+(todo) 

--- a/top_level_design/system_landscape.md
+++ b/top_level_design/system_landscape.md
@@ -8,8 +8,9 @@ This diagram provides a high-level overview of the system components.
 **Date:** Dec 17, 2025, **Author:** https://github.com/0xf1e, **Discussion:** https://github.com/OS2sandbox/os2skole-PoC/pull/46
 
 **Originally intended Audience and Purpose:**  
-(a) For our own team: Outline the project's technical requirements.  
-(b) For external partners and stakeholders: Outline the overall scope and integration points.
+
+* Our own team: "We want to see all system components on one diagram, so that we can better evaluate what kinds of partnerships we need to reach out for."
+* Potential technology partners: "We want to see where our own work and skills can fit into the OS2Skole project."
 
 ## Implied Decisions
 

--- a/top_level_design/system_landscape.md
+++ b/top_level_design/system_landscape.md
@@ -2,13 +2,13 @@
 
 This diagram provides a high-level overview of the system components.
 
-![C4 System Landscape Diagram](./top_level_design/diagram_data/system_landscape_diagram.svg)
+![C4 System Landscape Diagram](./diagram_data/system_landscape_diagram.svg)
 
 ## Context
-**Date:** Dec 17, 2025, **Author:** @0xf1e, **Discussion:** https://github.com/OS2sandbox/os2skole-PoC/pull/46
+**Date:** Dec 17, 2025, **Author:** https://github.com/0xf1e, **Discussion:** https://github.com/OS2sandbox/os2skole-PoC/pull/46
 
-**Originally intended Audience and Purpose:**
-(a) For our own team: Outline the project's technical requirements.
+**Originally intended Audience and Purpose:**  
+(a) For our own team: Outline the project's technical requirements.  
 (b) For external partners and stakeholders: Outline the overall scope and integration points.
 
 ## Implied Decisions

--- a/top_level_design/system_landscape.md
+++ b/top_level_design/system_landscape.md
@@ -5,11 +5,11 @@ This diagram provides a high-level overview of the system components.
 ![C4 System Landscape Diagram](./diagram_data/system_landscape_diagram.svg)
 
 ## Context
-**Date:** Dec 17, 2025, **Author:** https://github.com/0xf1e, **Discussion:** https://github.com/OS2sandbox/os2skole-PoC/pull/46
+**Date:** Dec 17, 2025, **Author:** [@0xf1e](https://github.com/0xf1e), **Discussion:** https://github.com/OS2sandbox/os2skole-PoC/pull/46
 
 **Originally intended Audience and Purpose:**  
 
-* Our own team: "We want to see all system components on one diagram, so that we can better evaluate what kinds of partnerships we need to reach out for."
+* Our own team: "We want to see all system components on one diagram, so that we can better assess risks and the project's feasibility."
 * Potential technology partners: "We want to see where our own work and skills can fit into the OS2Skole project."
 
 ## Implied Decisions


### PR DESCRIPTION
closes: #58 

This markdown structure draws on diagram-driven development: Diagrams should be made with certain recipients in mind, and they should convey decisions made by the designer.

I suggest annotating our diagrams with this context.

Also, given that diagrams often go stale, knowing the context of a diagram can help the reader evaluate how much weight they should be giving the diagram.